### PR TITLE
Dispose inner rendertarget when usually just setting the outer texture to Null

### DIFF
--- a/src/VideoPlayer.cs
+++ b/src/VideoPlayer.cs
@@ -231,6 +231,7 @@ namespace VL.MediaFoundation
             {
                 currentVideoFrame = null;
                 renderTarget?.Dispose();
+                renderTarget = null;
                 invalidated = true;
                 return;
             }

--- a/src/VideoPlayer.cs
+++ b/src/VideoPlayer.cs
@@ -230,6 +230,8 @@ namespace VL.MediaFoundation
             if (ReadyState <= ReadyState.HaveNothing)
             {
                 currentVideoFrame = null;
+                renderTarget?.Dispose();
+                invalidated = true;
                 return;
             }
 


### PR DESCRIPTION
-> that saves a lot of memory in cases where you have a lot ov videoplayers, but only some are playing (as soon as play is off, this code block gets called and the rendertarget gets disposed. to be sure to recreate it when started again, 'invalidated' is set to true)